### PR TITLE
chore(parla): Replace all occurences of ki-anfragen

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,5 +1,5 @@
 {
-	"projectName": "ki-anfragen-api",
+	"projectName": "@technologiestiftung/parla-api",
 	"projectOwner": "technologiestiftung",
 	"repoType": "github",
 	"repoHost": "https://github.com",
@@ -27,4 +27,3 @@
 	"skipCi": true,
 	"commitType": "docs"
 }
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,154 +1,154 @@
-## [1.13.1](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.13.0...v1.13.1) (2023-12-14)
+## [1.13.1](https://github.com/technologiestiftung/parla-api/compare/v1.13.0...v1.13.1) (2023-12-14)
 
 
 ### Bug Fixes
 
-* **CORS:** Allow parla.citylab-berlin.org ([989df48](https://github.com/technologiestiftung/ki-anfragen-api/commit/989df48a4eda89cb1892fced7d087d12fdeed518))
+* **CORS:** Allow parla.citylab-berlin.org ([989df48](https://github.com/technologiestiftung/parla-api/commit/989df48a4eda89cb1892fced7d087d12fdeed518))
 
-# [1.13.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.12.1...v1.13.0) (2023-12-11)
-
-
-### Bug Fixes
-
-* **DB:** Pull remote state of DB into migrations ([09efadb](https://github.com/technologiestiftung/ki-anfragen-api/commit/09efadb961f958ac435eb13615ccc42313e6d87e))
-* Initial index list size ([020e9da](https://github.com/technologiestiftung/ki-anfragen-api/commit/020e9daf96f6228f73df7d02860c97693388ab20))
-* **migrations:** Drop function before creation ([7417528](https://github.com/technologiestiftung/ki-anfragen-api/commit/74175287309c0cb3452490d13b2cbf4835ca24d9))
-* **migrations:** pgFormatter killed the <#> operator ([9efbdda](https://github.com/technologiestiftung/ki-anfragen-api/commit/9efbdda0093df37f433d9c26309af24006b5fabe))
-* Types on api_test ([7ec02cd](https://github.com/technologiestiftung/ki-anfragen-api/commit/7ec02cd0f32d4ed1587aa3a11790137b0342f9f6))
-
-
-### Features
-
-* Better logging in dev ([4bc5079](https://github.com/technologiestiftung/ki-anfragen-api/commit/4bc50795d0ab01f5cb2036272892f8e6febca74c))
-* **schema:** Use enum in schema ([63eab60](https://github.com/technologiestiftung/ki-anfragen-api/commit/63eab604775c7ea615ab929389dd4d15e49231f6))
-
-## [1.12.1](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.12.0...v1.12.1) (2023-11-29)
+# [1.13.0](https://github.com/technologiestiftung/parla-api/compare/v1.12.1...v1.13.0) (2023-12-11)
 
 
 ### Bug Fixes
 
-* cleanup db function params ([#40](https://github.com/technologiestiftung/ki-anfragen-api/issues/40)) ([2279a25](https://github.com/technologiestiftung/ki-anfragen-api/commit/2279a256fb5f5629ef1408cef9c13e15778d39aa))
-
-# [1.12.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.11.0...v1.12.0) (2023-11-27)
-
-
-### Features
-
-* refactoring into separate routes ([#38](https://github.com/technologiestiftung/ki-anfragen-api/issues/38)) ([cb4b501](https://github.com/technologiestiftung/ki-anfragen-api/commit/cb4b501609f69c132107db515df78f30f5856f2a))
-
-# [1.11.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.10.0...v1.11.0) (2023-11-23)
+* **DB:** Pull remote state of DB into migrations ([09efadb](https://github.com/technologiestiftung/parla-api/commit/09efadb961f958ac435eb13615ccc42313e6d87e))
+* Initial index list size ([020e9da](https://github.com/technologiestiftung/parla-api/commit/020e9daf96f6228f73df7d02860c97693388ab20))
+* **migrations:** Drop function before creation ([7417528](https://github.com/technologiestiftung/parla-api/commit/74175287309c0cb3452490d13b2cbf4835ca24d9))
+* **migrations:** pgFormatter killed the <#> operator ([9efbdda](https://github.com/technologiestiftung/parla-api/commit/9efbdda0093df37f433d9c26309af24006b5fabe))
+* Types on api_test ([7ec02cd](https://github.com/technologiestiftung/parla-api/commit/7ec02cd0f32d4ed1587aa3a11790137b0342f9f6))
 
 
 ### Features
 
-* functional tests with a set of predefined questions + route for counting docs ([#37](https://github.com/technologiestiftung/ki-anfragen-api/issues/37)) ([9c0019c](https://github.com/technologiestiftung/ki-anfragen-api/commit/9c0019cc83f237ed5ba578384bd5cc03ad01f9f0))
+* Better logging in dev ([4bc5079](https://github.com/technologiestiftung/parla-api/commit/4bc50795d0ab01f5cb2036272892f8e6febca74c))
+* **schema:** Use enum in schema ([63eab60](https://github.com/technologiestiftung/parla-api/commit/63eab604775c7ea615ab929389dd4d15e49231f6))
 
-# [1.10.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.9.0...v1.10.0) (2023-11-20)
-
-
-### Features
-
-* frontend can decide which search algorithm to use ([#32](https://github.com/technologiestiftung/ki-anfragen-api/issues/32)) ([512d008](https://github.com/technologiestiftung/ki-anfragen-api/commit/512d00806b096fbfe4f011c1a46e5479607a5faa))
-
-# [1.9.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.8.0...v1.9.0) (2023-11-16)
-
-
-### Features
-
-* add summary to prompt ([#31](https://github.com/technologiestiftung/ki-anfragen-api/issues/31)) ([8ccf872](https://github.com/technologiestiftung/ki-anfragen-api/commit/8ccf872fb2d1c7de7ef62dd56ca2228f52c1f4cb))
-
-# [1.8.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.7.0...v1.8.0) (2023-11-14)
-
-
-### Features
-
-* search in summary embeddings ([#30](https://github.com/technologiestiftung/ki-anfragen-api/issues/30)) ([2cdd8d8](https://github.com/technologiestiftung/ki-anfragen-api/commit/2cdd8d82ee9ff794bfa652d1c14305362c384083))
-
-# [1.7.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.6.0...v1.7.0) (2023-11-13)
-
-
-### Features
-
-* init supabase for new schema ([#28](https://github.com/technologiestiftung/ki-anfragen-api/issues/28)) ([753ecc0](https://github.com/technologiestiftung/ki-anfragen-api/commit/753ecc0684d94541dd9f68503e3109cf8be64df4))
-
-# [1.6.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.5.0...v1.6.0) (2023-11-02)
-
-
-### Features
-
-* search also in red number reports ([#26](https://github.com/technologiestiftung/ki-anfragen-api/issues/26)) ([5d45e8d](https://github.com/technologiestiftung/ki-anfragen-api/commit/5d45e8d2edb9bc51c811ee23750984065fcc7c24))
-
-# [1.5.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.4.1...v1.5.0) (2023-09-12)
+## [1.12.1](https://github.com/technologiestiftung/parla-api/compare/v1.12.0...v1.12.1) (2023-11-29)
 
 
 ### Bug Fixes
 
-* **json schema:** Remove respone schema ([9af8ffd](https://github.com/technologiestiftung/ki-anfragen-api/commit/9af8ffdc7d64a795cca8a7c10cfad09ff38c9011))
+* cleanup db function params ([#40](https://github.com/technologiestiftung/parla-api/issues/40)) ([2279a25](https://github.com/technologiestiftung/parla-api/commit/2279a256fb5f5629ef1408cef9c13e15778d39aa))
+
+# [1.12.0](https://github.com/technologiestiftung/parla-api/compare/v1.11.0...v1.12.0) (2023-11-27)
 
 
 ### Features
 
-* **schema:** This adds a reponse schema ([3171cda](https://github.com/technologiestiftung/ki-anfragen-api/commit/3171cdac5b66d4ebfc32725a268425ad367bb00a))
+* refactoring into separate routes ([#38](https://github.com/technologiestiftung/parla-api/issues/38)) ([cb4b501](https://github.com/technologiestiftung/parla-api/commit/cb4b501609f69c132107db515df78f30f5856f2a))
 
-## [1.4.1](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.4.0...v1.4.1) (2023-09-01)
+# [1.11.0](https://github.com/technologiestiftung/parla-api/compare/v1.10.0...v1.11.0) (2023-11-23)
+
+
+### Features
+
+* functional tests with a set of predefined questions + route for counting docs ([#37](https://github.com/technologiestiftung/parla-api/issues/37)) ([9c0019c](https://github.com/technologiestiftung/parla-api/commit/9c0019cc83f237ed5ba578384bd5cc03ad01f9f0))
+
+# [1.10.0](https://github.com/technologiestiftung/parla-api/compare/v1.9.0...v1.10.0) (2023-11-20)
+
+
+### Features
+
+* frontend can decide which search algorithm to use ([#32](https://github.com/technologiestiftung/parla-api/issues/32)) ([512d008](https://github.com/technologiestiftung/parla-api/commit/512d00806b096fbfe4f011c1a46e5479607a5faa))
+
+# [1.9.0](https://github.com/technologiestiftung/parla-api/compare/v1.8.0...v1.9.0) (2023-11-16)
+
+
+### Features
+
+* add summary to prompt ([#31](https://github.com/technologiestiftung/parla-api/issues/31)) ([8ccf872](https://github.com/technologiestiftung/parla-api/commit/8ccf872fb2d1c7de7ef62dd56ca2228f52c1f4cb))
+
+# [1.8.0](https://github.com/technologiestiftung/parla-api/compare/v1.7.0...v1.8.0) (2023-11-14)
+
+
+### Features
+
+* search in summary embeddings ([#30](https://github.com/technologiestiftung/parla-api/issues/30)) ([2cdd8d8](https://github.com/technologiestiftung/parla-api/commit/2cdd8d82ee9ff794bfa652d1c14305362c384083))
+
+# [1.7.0](https://github.com/technologiestiftung/parla-api/compare/v1.6.0...v1.7.0) (2023-11-13)
+
+
+### Features
+
+* init supabase for new schema ([#28](https://github.com/technologiestiftung/parla-api/issues/28)) ([753ecc0](https://github.com/technologiestiftung/parla-api/commit/753ecc0684d94541dd9f68503e3109cf8be64df4))
+
+# [1.6.0](https://github.com/technologiestiftung/parla-api/compare/v1.5.0...v1.6.0) (2023-11-02)
+
+
+### Features
+
+* search also in red number reports ([#26](https://github.com/technologiestiftung/parla-api/issues/26)) ([5d45e8d](https://github.com/technologiestiftung/parla-api/commit/5d45e8d2edb9bc51c811ee23750984065fcc7c24))
+
+# [1.5.0](https://github.com/technologiestiftung/parla-api/compare/v1.4.1...v1.5.0) (2023-09-12)
 
 
 ### Bug Fixes
 
-* **logging:** Logging needs first the object ([794680f](https://github.com/technologiestiftung/ki-anfragen-api/commit/794680f9e0200e8fcd63ac16641ed6ba15fe08db))
-
-# [1.4.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.3.0...v1.4.0) (2023-08-30)
+* **json schema:** Remove respone schema ([9af8ffd](https://github.com/technologiestiftung/parla-api/commit/9af8ffdc7d64a795cca8a7c10cfad09ff38c9011))
 
 
 ### Features
 
-* **response:** add more detail to response ([fc29f16](https://github.com/technologiestiftung/ki-anfragen-api/commit/fc29f16d71e6743d22f83d71598b482b4507376a))
+* **schema:** This adds a reponse schema ([3171cda](https://github.com/technologiestiftung/parla-api/commit/3171cdac5b66d4ebfc32725a268425ad367bb00a))
 
-# [1.3.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.2.0...v1.3.0) (2023-08-29)
-
-
-### Features
-
-* **body schema:** Extend schema with params ([e7095af](https://github.com/technologiestiftung/ki-anfragen-api/commit/e7095afc0ce68a3fffbb31222901e5245cbee9eb))
-* **search parameters:** Add opts to tweak request ([cf26f9e](https://github.com/technologiestiftung/ki-anfragen-api/commit/cf26f9e5fc1d2bd1925873e5dba10e8ad9b880ac))
-
-# [1.2.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.1.0...v1.2.0) (2023-08-28)
+## [1.4.1](https://github.com/technologiestiftung/parla-api/compare/v1.4.0...v1.4.1) (2023-09-01)
 
 
 ### Bug Fixes
 
-* **cors:** allow cors for / and /health ([c3b85e8](https://github.com/technologiestiftung/ki-anfragen-api/commit/c3b85e83988278862fc2363ba703679bcdc2916e))
-* **cors:** Allow locahost only in development ([ffa7f89](https://github.com/technologiestiftung/ki-anfragen-api/commit/ffa7f8995eb0d8fbe6bca0e5a78be6c7856120b7))
-* **cors:** Configure cors only for vector-search ([1f9b4cd](https://github.com/technologiestiftung/ki-anfragen-api/commit/1f9b4cd33ccf5fe743cc451f4ea38e4ed476996a))
-* **cors:** Don't allow request without origin ([b3626f7](https://github.com/technologiestiftung/ki-anfragen-api/commit/b3626f72de8d69f718ee85caf2c92a2bc0d7bbc0))
-* **origin:** pass if origin is undefined ([5f83e16](https://github.com/technologiestiftung/ki-anfragen-api/commit/5f83e16a2a010cd565bd76d817be65987c717178))
-* **test:** Allow tests to pass CORS ([32d4822](https://github.com/technologiestiftung/ki-anfragen-api/commit/32d4822035d4739c43eed792ecea2ea927762127))
-* **timeouts:** Move to Service role key ([e2789c1](https://github.com/technologiestiftung/ki-anfragen-api/commit/e2789c14fe91f858a51133953eb628625215f764))
-* **timeouts:** Move to Service role key ([e060f71](https://github.com/technologiestiftung/ki-anfragen-api/commit/e060f71b37f3e78c0a30a811b7bdece469f95d93))
+* **logging:** Logging needs first the object ([794680f](https://github.com/technologiestiftung/parla-api/commit/794680f9e0200e8fcd63ac16641ed6ba15fe08db))
+
+# [1.4.0](https://github.com/technologiestiftung/parla-api/compare/v1.3.0...v1.4.0) (2023-08-30)
 
 
 ### Features
 
-* **CORS:** Configure CORS based on regex ([778aa41](https://github.com/technologiestiftung/ki-anfragen-api/commit/778aa4145a1725eefea3464f9259e5c82424d1e8))
-* More control over logging ([61bde37](https://github.com/technologiestiftung/ki-anfragen-api/commit/61bde3793b1fbb7d6f0bb4974b6d1eaf4863d3df))
-* **prompt:** Fix wording in prompt ([c819e89](https://github.com/technologiestiftung/ki-anfragen-api/commit/c819e89a2e630fbbb5160bb286b84b2ce513d3ce))
+* **response:** add more detail to response ([fc29f16](https://github.com/technologiestiftung/parla-api/commit/fc29f16d71e6743d22f83d71598b482b4507376a))
 
-# [1.1.0](https://github.com/technologiestiftung/ki-anfragen-api/compare/v1.0.0...v1.1.0) (2023-08-24)
+# [1.3.0](https://github.com/technologiestiftung/parla-api/compare/v1.2.0...v1.3.0) (2023-08-29)
+
+
+### Features
+
+* **body schema:** Extend schema with params ([e7095af](https://github.com/technologiestiftung/parla-api/commit/e7095afc0ce68a3fffbb31222901e5245cbee9eb))
+* **search parameters:** Add opts to tweak request ([cf26f9e](https://github.com/technologiestiftung/parla-api/commit/cf26f9e5fc1d2bd1925873e5dba10e8ad9b880ac))
+
+# [1.2.0](https://github.com/technologiestiftung/parla-api/compare/v1.1.0...v1.2.0) (2023-08-28)
 
 
 ### Bug Fixes
 
-* **buildserver:** function is async now ([e066ee7](https://github.com/technologiestiftung/ki-anfragen-api/commit/e066ee7f106d4b8885cc743b6bcf37f327cadea6))
+* **cors:** allow cors for / and /health ([c3b85e8](https://github.com/technologiestiftung/parla-api/commit/c3b85e83988278862fc2363ba703679bcdc2916e))
+* **cors:** Allow locahost only in development ([ffa7f89](https://github.com/technologiestiftung/parla-api/commit/ffa7f8995eb0d8fbe6bca0e5a78be6c7856120b7))
+* **cors:** Configure cors only for vector-search ([1f9b4cd](https://github.com/technologiestiftung/parla-api/commit/1f9b4cd33ccf5fe743cc451f4ea38e4ed476996a))
+* **cors:** Don't allow request without origin ([b3626f7](https://github.com/technologiestiftung/parla-api/commit/b3626f72de8d69f718ee85caf2c92a2bc0d7bbc0))
+* **origin:** pass if origin is undefined ([5f83e16](https://github.com/technologiestiftung/parla-api/commit/5f83e16a2a010cd565bd76d817be65987c717178))
+* **test:** Allow tests to pass CORS ([32d4822](https://github.com/technologiestiftung/parla-api/commit/32d4822035d4739c43eed792ecea2ea927762127))
+* **timeouts:** Move to Service role key ([e2789c1](https://github.com/technologiestiftung/parla-api/commit/e2789c14fe91f858a51133953eb628625215f764))
+* **timeouts:** Move to Service role key ([e060f71](https://github.com/technologiestiftung/parla-api/commit/e060f71b37f3e78c0a30a811b7bdece469f95d93))
 
 
 ### Features
 
-* **CORS:** Allow cors ([c17bd14](https://github.com/technologiestiftung/ki-anfragen-api/commit/c17bd1471dccd180749ebdbec354066d4033b995))
+* **CORS:** Configure CORS based on regex ([778aa41](https://github.com/technologiestiftung/parla-api/commit/778aa4145a1725eefea3464f9259e5c82424d1e8))
+* More control over logging ([61bde37](https://github.com/technologiestiftung/parla-api/commit/61bde3793b1fbb7d6f0bb4974b6d1eaf4863d3df))
+* **prompt:** Fix wording in prompt ([c819e89](https://github.com/technologiestiftung/parla-api/commit/c819e89a2e630fbbb5160bb286b84b2ce513d3ce))
+
+# [1.1.0](https://github.com/technologiestiftung/parla-api/compare/v1.0.0...v1.1.0) (2023-08-24)
+
+
+### Bug Fixes
+
+* **buildserver:** function is async now ([e066ee7](https://github.com/technologiestiftung/parla-api/commit/e066ee7f106d4b8885cc743b6bcf37f327cadea6))
+
+
+### Features
+
+* **CORS:** Allow cors ([c17bd14](https://github.com/technologiestiftung/parla-api/commit/c17bd1471dccd180749ebdbec354066d4033b995))
 
 # 1.0.0 (2023-08-24)
 
 
 ### Features
 
-* Docker setup ([c069eaf](https://github.com/technologiestiftung/ki-anfragen-api/commit/c069eafda24ef248f233c3f450d8f7ebc4bc1f32))
-* First working version ([8d61233](https://github.com/technologiestiftung/ki-anfragen-api/commit/8d61233980584951100e4609a48eedb46c92d877))
+* Docker setup ([c069eaf](https://github.com/technologiestiftung/parla-api/commit/c069eafda24ef248f233c3f450d8f7ebc4bc1f32))
+* First working version ([8d61233](https://github.com/technologiestiftung/parla-api/commit/8d61233980584951100e4609a48eedb46c92d877))

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-# _>ki.anfragen (api & database)_
+# _Parla (api & database)_
 
-This is a the api and database for the explorational project _>ki.anfragen_. This is not production ready. Currently we explore if we can make the parliamentary documentation provided by the "The Abgeordnetenhaus" of Berlin as open data https://www.parlament-berlin.de/dokumente/open-data more accessible by embedding all the data and do search it using vector similarity search. The project is heavily based on [this example](https://github.com/supabase-community/nextjs-openai-doc-search) from the supabase community. Built with [Fastify](https://fastify.dev/) and deployed to [render.com](https://render.com) using [docker](https://www.docker.com/).
+This is a the api and database for the explorational project _Parla_. This is not production ready. Currently we explore if we can make the parliamentary documentation provided by the "The Abgeordnetenhaus" of Berlin as open data https://www.parlament-berlin.de/dokumente/open-data more accessible by embedding all the data and do search it using vector similarity search. The project is heavily based on [this example](https://github.com/supabase-community/nextjs-openai-doc-search) from the supabase community. Built with [Fastify](https://fastify.dev/) and deployed to [render.com](https://render.com) using [docker](https://www.docker.com/).
 
 ## Prerequisites
 
 - docker
 - vercel.com account
 - supabase.com account
-- running instance of the related frontend https://github.com/technologiestiftung/ki-anfragen-frontend
+- running instance of the related frontend https://github.com/technologiestiftung/parla-frontend
 - running instance of the database, defined in [./supabase](./supabase)
-- populated database. Using these tools https://github.com/technologiestiftung/ki-anfragen-document-processor
+- populated database. Using these tools https://github.com/technologiestiftung/parla-document-processor
 
 ## Needed Environment Variables
 
@@ -93,8 +93,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top" width="14.28%"><a href="https://fabianmoronzirfas.me"><img src="https://avatars.githubusercontent.com/u/315106?v=4?s=64" width="64px;" alt="Fabian Morón Zirfas"/><br /><sub><b>Fabian Morón Zirfas</b></sub></a><br /><a href="https://github.com/technologiestiftung/ki-anfragen-api/commits?author=ff6347" title="Code">💻</a> <a href="#infra-ff6347" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#design-ff6347" title="Design">🎨</a> <a href="https://github.com/technologiestiftung/ki-anfragen-api/commits?author=ff6347" title="Documentation">📖</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Jaszkowic"><img src="https://avatars.githubusercontent.com/u/10830180?v=4?s=64" width="64px;" alt="Jonas Jaszkowic"/><br /><sub><b>Jonas Jaszkowic</b></sub></a><br /><a href="https://github.com/technologiestiftung/ki-anfragen-api/commits?author=Jaszkowic" title="Code">💻</a> <a href="#ideas-Jaszkowic" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/technologiestiftung/ki-anfragen-api/commits?author=Jaszkowic" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://fabianmoronzirfas.me"><img src="https://avatars.githubusercontent.com/u/315106?v=4?s=64" width="64px;" alt="Fabian Morón Zirfas"/><br /><sub><b>Fabian Morón Zirfas</b></sub></a><br /><a href="https://github.com/technologiestiftung/parla-api/commits?author=ff6347" title="Code">💻</a> <a href="#infra-ff6347" title="Infrastructure (Hosting, Build-Tools, etc)">🚇</a> <a href="#design-ff6347" title="Design">🎨</a> <a href="https://github.com/technologiestiftung/parla-api/commits?author=ff6347" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/Jaszkowic"><img src="https://avatars.githubusercontent.com/u/10830180?v=4?s=64" width="64px;" alt="Jonas Jaszkowic"/><br /><sub><b>Jonas Jaszkowic</b></sub></a><br /><a href="https://github.com/technologiestiftung/parla-api/commits?author=Jaszkowic" title="Code">💻</a> <a href="#ideas-Jaszkowic" title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/technologiestiftung/parla-api/commits?author=Jaszkowic" title="Documentation">📖</a></td>
     </tr>
   </tbody>
 </table>
@@ -136,8 +136,8 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## Related Projects
 
-- https://github.com/technologiestiftung/ki-anfragen-frontend
-- https://github.com/technologiestiftung/ki-anfragen-data-extractor
-- https://github.com/technologiestiftung/ki-anfragen-supabase
+- https://github.com/technologiestiftung/parla-frontend
+- https://github.com/technologiestiftung/parla-data-extractor
+- https://github.com/technologiestiftung/parla-supabase
 - https://github.com/technologiestiftung/oeffentliches-gestalten-gpt-search
 - https://github.com/supabase-community/nextjs-openai-doc-search

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   api:
-    image: ki-anfragen-api
+    image: parla-api
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   api:
-    image: ki-anfragen-api
+    image: parla-api
     platform:  linux/arm64/v8
     build:
       context: .

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ default:
 docker-build:
 	docker build \
 		--platform linux/amd64 \
-		--tag technologiestiftung/ki-anfragen-api .
+		--tag technologiestiftung/parla-api .
 
 docker-run:
 	docker run --env SUPABASE_URL="$SUPABASE_URL" \
@@ -19,4 +19,4 @@ docker-run:
 		--interactive \
 		--tty \
 		--publish 8080:8080 \
-		technologiestiftung/ki-anfragen-api
+		technologiestiftung/parla-api

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "ki-anfragen-api",
+	"name": "@technologiestiftung/parla-api",
 	"version": "1.13.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "ki-anfragen-api",
+			"name": "@technologiestiftung/parla-api",
 			"version": "1.13.1",
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "ki-anfragen-api",
+	"name": "@technologiestiftung/parla-api",
 	"version": "1.13.1",
 	"description": "",
 	"main": "dist/index.js",

--- a/src/lib/handle-cors.ts
+++ b/src/lib/handle-cors.ts
@@ -33,7 +33,7 @@ export async function registerCors(app: FastifyInstance) {
 			// match hosstname based on regex
 			if (
 				hostname.match(
-					/cors-requester.vercel.app|ki-anfragen-frontend.*?.vercel.app|ki-anfragen.citylab-berlin.org|parla.citylab-berlin.org/,
+					/cors-requester.vercel.app|parla-frontend.*?.vercel.app|ki-anfragen-frontend.*?.vercel.app|ki-anfragen.citylab-berlin.org|parla.citylab-berlin.org/,
 				)
 			) {
 				//  Request from localhost will pass

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,6 +1,6 @@
 # A string used to distinguish different Supabase projects on the same host. Defaults to the working
 # directory name when running `supabase init`.
-project_id = "ki-anfragen-database"
+project_id = "parla-database"
 
 [api]
 # Port to use for the API URL.


### PR DESCRIPTION
This PR replaces all occurrences of ki-anfragen with parla. It should be merged before PR https://github.com/technologiestiftung/ki-anfragen-frontend/pull/57 on the frontend.

Steps to take:

- [x] Rename repo. (Will not affect render)
- [x] Create new service on render.com
- [x] Link to env group in render and make sure all variables are the right ones
- [x] Adjust DNS CNAME entry for api.parla.citylab-berlin.org to point to new service
- [x] Make sure CNAME is working `dig api.parla.citylab-berlin.org`
- [x] Move on to PR on frontend https://github.com/technologiestiftung/ki-anfragen-frontend/pull/57
