### PR TITLE
fix(db): cleanup old indices on regeneration

### DIFF
--- a/supabase/migrations/20240220134435_fix_generate_indices_function_summaries.sql
+++ b/supabase/migrations/20240220134435_fix_generate_indices_function_summaries.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE FUNCTION public.regenerate_embedding_indices_for_summaries()
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+BEGIN 
+
+DO $$
+DECLARE 
+    index_name TEXT;
+    numRows INT;
+BEGIN 
+    -- Delete old embedding indices first
+    FOR index_name IN
+        SELECT indexname FROM pg_indexes WHERE indexname LIKE '%processed_document_summaries_summary_embedding_idx%'
+    LOOP
+        EXECUTE 'DROP INDEX IF EXISTS ' || index_name;
+    END LOOP;
+
+    -- Generate new embedding indices
+    SELECT ROUND(COUNT(*) / 1000) INTO numRows FROM processed_document_summaries;
+
+    EXECUTE 'CREATE INDEX ON processed_document_summaries USING ivfflat (summary_embedding vector_l2_ops) WITH (lists = ' || numRows || ')';
+    EXECUTE 'CREATE INDEX ON processed_document_summaries USING ivfflat (summary_embedding vector_ip_ops) WITH (lists = ' || numRows || ')';
+    EXECUTE 'CREATE INDEX ON processed_document_summaries USING ivfflat (summary_embedding vector_cosine_ops) WITH (lists = ' || numRows || ')';
+END $$;
+
+END;
+$function$


### PR DESCRIPTION
there was a typo which caused indices to accumulate on every (daily) regeneration:

` SELECT indexname FROM pg_indexes WHERE indexname LIKE '%processed_document_summaries_embedding_idx%'`

which is now corrected to:

` SELECT indexname FROM pg_indexes WHERE indexname LIKE '%processed_document_summaries_summary_embedding_idx%'`

This also caused the database to grow much larger than it should be. After my cleanup of the duplicated indices, the database is now 5-6GB large only.



