### PR TITLE
fix: cors for feedback routes

### DIFF
--- a/src/lib/handle-cors.ts
+++ b/src/lib/handle-cors.ts
@@ -5,9 +5,11 @@ import cors from "@fastify/cors";
 export async function registerCors(app: FastifyInstance) {
 	await app.register(cors, {
 		origin: (origin, cb) => {
+			// console.log("cors", origin);
 			if (
 				process.env.DANGEROUSLY_ALLOW_CORS_FOR_ALL_ORIGINS === "FOR_REAL_REAL"
 			) {
+				// console.log("DANGEROUSLY_ALLOW_CORS_FOR_ALL_ORIGINS");
 				app.log.warn("DANGEROUSLY_ALLOW_CORS_FOR_ALL_ORIGINS");
 				return cb(null, true);
 			}
@@ -18,6 +20,7 @@ export async function registerCors(app: FastifyInstance) {
 				return cb(null, true);
 			}
 			if (!origin) {
+				// console.log("No origin in request");
 				app.log.warn("No origin in request");
 				cb(new Error("Not allowed"), false);
 				return;

--- a/src/lib/handle-cors.ts
+++ b/src/lib/handle-cors.ts
@@ -5,11 +5,9 @@ import cors from "@fastify/cors";
 export async function registerCors(app: FastifyInstance) {
 	await app.register(cors, {
 		origin: (origin, cb) => {
-			// console.log("cors", origin);
 			if (
 				process.env.DANGEROUSLY_ALLOW_CORS_FOR_ALL_ORIGINS === "FOR_REAL_REAL"
 			) {
-				// console.log("DANGEROUSLY_ALLOW_CORS_FOR_ALL_ORIGINS");
 				app.log.warn("DANGEROUSLY_ALLOW_CORS_FOR_ALL_ORIGINS");
 				return cb(null, true);
 			}
@@ -20,7 +18,6 @@ export async function registerCors(app: FastifyInstance) {
 				return cb(null, true);
 			}
 			if (!origin) {
-				// console.log("No origin in request");
 				app.log.warn("No origin in request");
 				cb(new Error("Not allowed"), false);
 				return;

--- a/src/lib/routes/feedback-route.ts
+++ b/src/lib/routes/feedback-route.ts
@@ -16,15 +16,9 @@ export async function feedbackRoute(
 		schema: {
 			querystring: { id: { type: "number" } },
 		},
-		method: ["GET", "HEAD", "OPTIONS"],
+		method: ["GET"],
 		handler: async (request, reply) => {
 			switch (request.method) {
-				case "HEAD":
-					reply.send();
-					break;
-				case "OPTIONS":
-					reply.send();
-					break;
 				case "GET":
 					{
 						const { id } = request.query;

--- a/src/lib/routes/feedback-route.ts
+++ b/src/lib/routes/feedback-route.ts
@@ -1,14 +1,14 @@
 import { FastifyInstance } from "fastify";
 import { supabase } from "../supabase.js";
 import { UserError } from "../errors.js";
+import { registerCors } from "../handle-cors.js";
 
-export function feedbackRoute(
+export async function feedbackRoute(
 	app: FastifyInstance,
 	_options: unknown,
 	next: (err?: Error | undefined) => void,
 ) {
-	// app.get("/", (req, res) => {
-
+	await registerCors(app);
 	app.route<{
 		Querystring: { id?: number };
 	}>({

--- a/src/tests/feedback.test.ts
+++ b/src/tests/feedback.test.ts
@@ -80,23 +80,14 @@ test("feedbacks route options should return 200", async (t) => {
 			port: 8888,
 			protocol: "http",
 		},
-	};
-	const response = await t.context.server.inject(opts);
-	t.is(response.statusCode, 200);
-});
-
-test("feedbacks route head should return 200", async (t) => {
-	const opts: InjectOptions = {
-		method: "HEAD",
-		url: {
-			pathname: "/feedbacks",
-			hostname: "localhost",
-			port: 8888,
-			protocol: "http",
+		headers: {
+			"access-control-request-method": "GET",
+			"access-control-request-headers": "content-type",
+			origin: "http://localhost:3000",
 		},
 	};
 	const response = await t.context.server.inject(opts);
-	t.is(response.statusCode, 200);
+	t.is(response.statusCode, 204);
 });
 
 test("feedbacks route POST should return 400 due to missing body", async (t) => {


### PR DESCRIPTION
Using the `handleCors` function instead of handling CORS explicitly again on request level. Remove the HEAD test, because it is not a valid CORS request. Adjusted the OPTIONS request in test to be a valid preflight request.