### PR TITLE
feat: remove unused indices

### DIFF
--- a/supabase/migrations/20241112144401_remove_unused_indices.sql
+++ b/supabase/migrations/20241112144401_remove_unused_indices.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE FUNCTION public.regenerate_embedding_indices_for_chunks()
+    RETURNS void 
+    LANGUAGE plpgsql
+AS $function$ 
+
+BEGIN 
+
+DO $$
+DECLARE 
+    index_name TEXT;
+    numRows INT;
+
+BEGIN
+    -- Delete old embedding indices first
+    FOR index_name IN
+        SELECT indexname FROM pg_indexes WHERE indexname LIKE '%processed_document_chunks_embedding_idx%'
+    LOOP
+        EXECUTE 'DROP INDEX IF EXISTS ' || index_name;
+    END LOOP;
+
+    -- Generate new embedding indices
+    SELECT ROUND(COUNT(*) / 1000) INTO numRows FROM processed_document_chunks;
+
+    EXECUTE 'CREATE INDEX ON processed_document_chunks USING ivfflat (embedding vector_ip_ops) WITH (lists = ' || numRows || ')';
+END $$;
+
+END;
+$function$

--- a/supabase/migrations/20241112144454_remove_unused_indices_summaries.sql
+++ b/supabase/migrations/20241112144454_remove_unused_indices_summaries.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION public.regenerate_embedding_indices_for_summaries()
+    RETURNS void 
+    LANGUAGE plpgsql
+AS $function$
+BEGIN 
+
+DO $$
+DECLARE 
+    index_name TEXT;
+    numRows INT;
+BEGIN 
+    -- Delete old embedding indices first
+    FOR index_name IN
+        SELECT indexname FROM pg_indexes WHERE indexname LIKE '%processed_document_summaries_embedding_idx%'
+    LOOP
+        EXECUTE 'DROP INDEX IF EXISTS ' || index_name;
+    END LOOP;
+
+    -- Generate new embedding indices
+    SELECT ROUND(COUNT(*) / 1000) INTO numRows FROM processed_document_summaries;
+
+    EXECUTE 'CREATE INDEX ON processed_document_summaries USING ivfflat (summary_embedding vector_ip_ops) WITH (lists = ' || numRows || ')';
+END $$;
+
+END;
+$function$


### PR DESCRIPTION
https://app.asana.com/0/1205231177119914/1208717360321229

We have unused pgvector indices which we are not using, since we only use the ` <#>` operator

this migration will assure that on next registering and processing of documents, the unused indices will be removed