### PR TITLE
fix: replace guessable short_ids for user_requests with random ids

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -275,7 +275,7 @@ export type Database = {
 					moderation_time_ms: number | null;
 					question: string;
 					request_payload: Json;
-					short_id: string | null;
+					short_id: string;
 					summary_ids_in_context: number[] | null;
 				};
 				Insert: {
@@ -293,7 +293,7 @@ export type Database = {
 					moderation_time_ms?: number | null;
 					question: string;
 					request_payload: Json;
-					short_id?: string | null;
+					short_id?: string;
 					summary_ids_in_context?: number[] | null;
 				};
 				Update: {
@@ -311,7 +311,7 @@ export type Database = {
 					moderation_time_ms?: number | null;
 					question?: string;
 					request_payload?: Json;
-					short_id?: string | null;
+					short_id?: string;
 					summary_ids_in_context?: number[] | null;
 				};
 				Relationships: [];
@@ -341,37 +341,10 @@ export type Database = {
 					metadata: Json;
 				}[];
 			};
-			hash_encode: {
-				Args: {
-					"": number;
-				};
+			generate_random_short_id: {
+				Args: Record<PropertyKey, never>;
 				Returns: string;
 			};
-			id_decode: {
-				Args: {
-					"": string;
-				};
-				Returns: number[];
-			};
-			id_decode_once: {
-				Args: {
-					"": string;
-				};
-				Returns: number;
-			};
-			id_encode:
-				| {
-						Args: {
-							"": number[];
-						};
-						Returns: string;
-				  }
-				| {
-						Args: {
-							"": number;
-						};
-						Returns: string;
-				  };
 			json_matches_schema: {
 				Args: {
 					schema: Json;

--- a/src/tests/feedback.test.ts
+++ b/src/tests/feedback.test.ts
@@ -230,7 +230,10 @@ test("feedbacks route POST should return 400 due to wrong property feedback_id i
 		headers: {
 			"content-type": "application/json",
 		},
-		body: JSON.stringify({ feedback_id: 999999, user_request_id: "jR" }),
+		body: JSON.stringify({
+			feedback_id: 999999,
+			user_request_id: "seeded_short_id_1",
+		}),
 	};
 	const response = await t.context.server.inject(opts);
 	// FIXME: This will change with PR https://github.com/technologiestiftung/parla-api/pull/87
@@ -257,7 +260,7 @@ test("feedbacks route POST should return 201", async (t) => {
 		},
 		body: JSON.stringify({
 			feedback_id,
-			user_request_id: "jR",
+			user_request_id: "seeded_short_id_1",
 			session_id: "abcdefg",
 		}),
 	};

--- a/src/tests/load-user-request.test.ts
+++ b/src/tests/load-user-request.test.ts
@@ -24,7 +24,7 @@ test("load user request should return reconstructed request/response object", as
 	const opts: InjectOptions = {
 		method: "GET",
 		url: {
-			pathname: "/requests/jR", // jR is encoded short id for numeric id = 1
+			pathname: "/requests/seeded_short_id_1", // fixed short_id pinned by supabase/seed.sql
 			hostname: "localhost",
 			port: 8888,
 			protocol: "http",

--- a/supabase/migrations/20260624120000_secure_user_request_short_ids.sql
+++ b/supabase/migrations/20260624120000_secure_user_request_short_ids.sql
@@ -1,0 +1,32 @@
+-- Security fix: replace enumerable predictable hashids short_ids with unguessable random tokens.
+
+-- 1. Helper that returns a random, URL-safe 12-char token.
+--    The uuid's 16 random bytes are base64-encoded, trimmed to 12 chars. Marked
+--    VOLATILE so it is evaluated fresh per row (not cached), giving each row a distinct id.
+CREATE OR REPLACE FUNCTION generate_random_short_id()
+RETURNS text
+LANGUAGE sql
+VOLATILE
+AS $$
+  SELECT translate(
+    left(encode(decode(replace(gen_random_uuid()::text, '-', ''), 'hex'), 'base64'), 12),
+    '+/', '-_'
+  );
+$$;
+
+-- 2. Generate new ids via a column default instead of the old trigger. Drop the now-redundant trigger + function.
+DROP TRIGGER IF EXISTS trigger_on_insert_user_requests ON user_requests;
+DROP FUNCTION IF EXISTS generate_short_id();
+ALTER TABLE user_requests ALTER COLUMN short_id SET DEFAULT generate_random_short_id();
+
+-- 3. Rotate every existing short_id so historical rows are no longer enumerable.
+UPDATE user_requests
+SET short_id = generate_random_short_id()
+WHERE short_id IS NULL OR short_id !~ '^[A-Za-z0-9_-]{12}$';
+
+-- 4. Enforce presence and uniqueness of short_id at the database level.
+ALTER TABLE user_requests ALTER COLUMN short_id SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS user_requests_short_id_key ON user_requests (short_id);
+
+-- 5. Drop pg_hashids.
+DROP EXTENSION IF EXISTS pg_hashids;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -35,8 +35,8 @@ SELECT
 		SELECT
 			* FROM regenerate_embedding_indices_for_summaries() $$);
 
-INSERT INTO user_requests(created_at, request_payload, question, generated_answer, llm_model, llm_embedding_model, moderation_time_ms, embedding_time_ms, database_search_time_ms, chat_completion_time_ms, matching_documents)
-	VALUES (now(), '{
+INSERT INTO user_requests(created_at, short_id, request_payload, question, generated_answer, llm_model, llm_embedding_model, moderation_time_ms, embedding_time_ms, database_search_time_ms, chat_completion_time_ms, matching_documents)
+	VALUES (now(), 'seeded_short_id_1', '{
     "query": "Wie viele Dachflächen mit Solaranlagen gibt es?",
     "match_threshold": 0.5,
     "num_probes_chunks": 9,


### PR DESCRIPTION
**What changed:** Public request IDs (`short_id`) are now random, unguessable tokens, a URL-safe 12-character string (~66 bits of entropy), generated via a column default (replacing the old insert trigger). Note: the short_id of all existing requests were also rotated, a `NOT NULL` + `UNIQUE` constraint on the column was added, and the now-unused `pg_hashids` extension was removed.

**Why:** The old IDs were predictable (1 → jR, 2 → k5, …). Because Hashids is reversible obfuscation over a counter, anyone could enumerate the ID space and read every stored request (each containing a user's question and the AI-generated answer) via `GET /requests/:short_id`. Random tokens close this; IDs can no longer be guessed or walked.

What it means for existing users:
* New requests: no visible change. Each question still produces a shareable result link; the link just looks different and is now unguessable.
* Their own history ("Fragenverlauf"): unaffected. It lives in the browser's **localStorage** and restores from there without calling the API, so nothing disappears.
* Old shared/bookmarked links: these stop working (return "not found"). Because existing IDs are rotated, any link created before this change, e.g. one shared with another person or opened on a different device, no longer resolves. 
The alternative, generating random IDs only for new requests while leaving existing ones untouched, would keep old links working, but every request created before the fix would stay enumerable.